### PR TITLE
CLD-14-fix/locker-delete-failure

### DIFF
--- a/src/pages/Locker/LockerPage.jsx
+++ b/src/pages/Locker/LockerPage.jsx
@@ -90,8 +90,8 @@ export default function LockerPage() {
 
   const statusText = (status) => {
     switch (status) {
-      case "empty":
-        return;
+      case "other":
+        return "사용 중단된 사물함입니다";
       case "request":
         return "대여가 신청된 사물함입니다";
       case "return":
@@ -99,22 +99,22 @@ export default function LockerPage() {
       case "using":
         return "사용중";
       default:
-        return "사용중단";
+        return "";
     }
   };
 
   const statusColor = (status) => {
     switch (status) {
-      case "empty":
-        return "#FFFFFF";
       case "request":
         return "#F4D364";
       case "return":
         return "#92E1D4";
       case "using":
         return "#8C52FF";
-      default:
+      case "other":
         return "#E05E76";
+      default:
+        return "#FFFFFF";
     }
   };
 

--- a/src/pages/User/Mypage.jsx
+++ b/src/pages/User/Mypage.jsx
@@ -156,22 +156,34 @@ export default function Mypage() {
   }
 
   function handleDeleteAllLockers() {
-    // 서버에 사물함 삭제 요청 전송
-    Swal.fire("확인", "사물함 전체를 삭제합니다.", "info");
-
-    axios
-      .delete(`${process.env.REACT_APP_API_URL}/nemo/lockers`, {
-        headers: {
-          "nemo-access-token": userjwt,
-        },
-      })
-      .then((res) => {
-        setLockerInfo({ location: "", deposit: 0, row: 0, col: 0, order: "" });
-        if (res.data.isSuccess) {
-          Swal.fire("성공", "사물함 전체 삭제에 성공하였습니다.", "success");
-        }
-        navigate("/lockerinfo");
-      });
+    Swal.fire({
+      title: "정말로 삭제하시겠습니까?",
+      text: "사물함 전체를 삭제합니다",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonText: "삭제",
+      cancelButtonText: "취소",
+    }).then((result) => {
+      if (result.isConfirmed) {
+        // 서버에 사물함 삭제 요청 전송
+        axios
+          .delete(`${process.env.REACT_APP_API_URL}/nemo/lockers`, {
+            headers: {
+              "nemo-access-token": userjwt,
+            },
+          })
+          .then((res) => {
+            console.log(res.data);
+            if (res.data.isSuccess) {
+              setLockerInfo({ location: "", deposit: 0, row: 0, col: 0, order: "" });
+              Swal.fire("사물함 삭제가 완료되었습니다", "사물함 재등록 페이지로 이동됩니다", "success");
+              navigate("/lockerinfo");
+            } else {
+              Swal.fire("실패", "모든 사물함에 대해 단 하나의 요청이라도 있으면 삭제할 수 없습니다. 다시 확인해주세요", "error");
+            }
+          });
+      }
+    });
   }
 
   // 탈퇴하기 버튼 클릭 시


### PR DESCRIPTION
1. 사물함 삭제 건에 대한 백엔드 return값 수정으로 부득이하게 api 요청 성공/실패 확인하는 로직 수정.
2. 사물함 삭제 시 정말로 삭제할 지 한번 더 묻는 modal 추가
3. 사물함 표시의 default 값을 empty에 맞춰서 흰색 배경의 내부 텍스트 없는 것으로 수정