### PR TITLE
fix: 사물함 등록 시 행렬 값 범위 오류 수정 #1

### DIFF
--- a/src/pages/Locker/LockerInfo.jsx
+++ b/src/pages/Locker/LockerInfo.jsx
@@ -188,6 +188,7 @@ export default function LockerInfo() {
               <Form.Control
                 type="number"
                 name="row"
+                min="3"
                 onChange={handleOnChange}
                 placeholder="행 입력"
                 className="formControl"
@@ -204,6 +205,7 @@ export default function LockerInfo() {
               <Form.Control
                 type="number"
                 name="col"
+                min="3"
                 onChange={handleOnChange}
                 placeholder="열 입력"
                 className="formControl"


### PR DESCRIPTION
1. 관리자가 사물함 생성 시 입력 가능한 최소 행렬 값이 '3'이 되도록 수정
2. 행렬을 설정하는 Form.Control의 요소에 min값을 3으로 설정하는 부분 추가